### PR TITLE
Replace URLS in H5P activities

### DIFF
--- a/classes/logger.php
+++ b/classes/logger.php
@@ -76,7 +76,11 @@ class tool_kaltura_migration_logger {
     echo '<tr><td>' . $this->currentEntry . ($name ? '(' . $name . ')' : '') . '</td><td>';
   }
   public function content($content) {
-    echo '<td>' . $content . '</td>';
+    echo $content . '</td><td>';
+  }
+  public function codeContent($content) {
+    $content = '<div style="white-space: pre-wrap; font-family: monospace; max-width: 500px; max-height: 500px; overflow: scroll;">' . $content . "</div>";
+    $this->content($content);
   }
   /**
    * @param int $level Use level constans from this class.

--- a/tests/kaltura_migration_testcase.php
+++ b/tests/kaltura_migration_testcase.php
@@ -38,9 +38,8 @@ class kaltura_migration_testcase extends advanced_testcase {
       $this->assertEquals($urls[0], 'https://tube.switch.ch/video/1234567890?embed=true');
       $this->assertEquals($urls[1], 'http://cast.switch.ch/casts/123');
       $this->assertEquals($urls[2], 'https://download.cast.switch.ch/ethz-ch/switchcast-player/a6d933d9-8513-4a18-8eea-d36ebb2f1357/463fd0cc-0b82-4aba-9d5c-840667b4e7fd/Learning_goals.mp4');
-      $this->assertEquals($urls[3], 'https://tube.switch.ch/channels/bF7N6sNLse',
-      $this->assertEquals($urls[4], 'https://tube.switch.ch/external/u1KUHLZp7h')
-      );
+      $this->assertEquals($urls[3], 'https://tube.switch.ch/channels/bF7N6sNLse');
+      $this->assertEquals($urls[4], 'https://tube.switch.ch/external/u1KUHLZp7h');
    }
    public function test_extract_refids() {
       $urls = [

--- a/tests/kaltura_migration_testcase.php
+++ b/tests/kaltura_migration_testcase.php
@@ -30,24 +30,27 @@ class kaltura_migration_testcase extends advanced_testcase {
       $text = 'XXX aaa <a href="https://tube.switch.ch/video/1234567890?embed=true">video link</a>' . "\n"
          . 'http://cast.switch.ch/casts/123 http://cast.switch.com/casts/123' ."\n"
          . '<iframe src="https://download.cast.switch.ch/ethz-ch/switchcast-player/a6d933d9-8513-4a18-8eea-d36ebb2f1357/463fd0cc-0b82-4aba-9d5c-840667b4e7fd/Learning_goals.mp4"></iframe>' . "\n"
-         .  'And finally look at the channel <a href="https://tube.switch.ch/channels/bF7N6sNLse">https://tube.switch.ch/channels/bF7N6sNLse</a>' ;
+         .  'And finally look at the channel <a href="https://tube.switch.ch/channels/bF7N6sNLse">https://tube.switch.ch/channels/bF7N6sNLse</a>'
+         . 'And the external url: {"url": "https://tube.switch.ch/external/u1KUHLZp7h"}' ;
       $migration = new testable_kaltura_migration_controller();
       $urls = $migration->extractUrls($text);
       $this->assertEquals(count($urls), 5);
       $this->assertEquals($urls[0], 'https://tube.switch.ch/video/1234567890?embed=true');
       $this->assertEquals($urls[1], 'http://cast.switch.ch/casts/123');
       $this->assertEquals($urls[2], 'https://download.cast.switch.ch/ethz-ch/switchcast-player/a6d933d9-8513-4a18-8eea-d36ebb2f1357/463fd0cc-0b82-4aba-9d5c-840667b4e7fd/Learning_goals.mp4');
-      $this->assertEquals($urls[3], 'https://tube.switch.ch/channels/bF7N6sNLse');
-      $this->assertEquals($urls[4], 'https://tube.switch.ch/channels/bF7N6sNLse');
+      $this->assertEquals($urls[3], 'https://tube.switch.ch/channels/bF7N6sNLse',
+      $this->assertEquals($urls[4], 'https://tube.switch.ch/external/u1KUHLZp7h')
+      );
    }
    public function test_extract_refids() {
       $urls = [
          'https://tube.switch.ch/video/KIYKnxzVr3?embed=true',
          'https://cast.switch.ch/casts/gjuqKSPL24',
          'https://download.cast.switch.ch/ethz-ch/switchcast-player/a6d933d9-8513-4a18-8eea-d36ebb2f1357/463fd0cc-0b82-4aba-9d5c-840667b4e7fd/Learning_goals.mp4',
-         'https://tube.switch.ch/channels/bF7N6sNLse'
+         'https://tube.switch.ch/channels/bF7N6sNLse',
+         'https://tube.switch.ch/external/u1KUHLZp7h'
          ];
-      $expected = ['KIYKnxzVr3', 'gjuqKSPL24', 'a6d933d9-8513-4a18-8eea-d36ebb2f1357,463fd0cc-0b82-4aba-9d5c-840667b4e7fd', 'bF7N6sNLse'];
+      $expected = ['KIYKnxzVr3', 'gjuqKSPL24', 'a6d933d9-8513-4a18-8eea-d36ebb2f1357,463fd0cc-0b82-4aba-9d5c-840667b4e7fd', 'bF7N6sNLse', 'u1KUHLZp7h'];
       $migration = new testable_kaltura_migration_controller();
       foreach($urls as $i => $url) {
          $refids = $migration->getReferenceIdsFromUrl($url);

--- a/version.php
+++ b/version.php
@@ -24,12 +24,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022062008; // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2022062009; // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2020060900; // Requires this Moodle version
 $plugin->component = 'tool_kaltura_migration'; // Full name of the plugin (used for diagnostics)
 
 $plugin->maturity  = MATURITY_RC; // this version's maturity level
-$plugin->release   = 'v0.8';
+$plugin->release   = 'v0.9';
 
 $plugin->dependencies = array(
     'local_kaltura' => 2020121539,


### PR DESCRIPTION
Urls in H5P activities are within JSON-encoded fields. These fields have the slashes escaped (as allowed by the JSON spec, although not required). This PR adds support for replacing URLS in these JSON fields and as a result it allows to replace URLs in H5P activities, bth for the 'hvp' module and for the 'h5pactivity' module.